### PR TITLE
[CHORE]: Use compileSdkVersion 36 to make it compatible with the latest version of gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         namespace 'com.example.flutter_thermal_printer'
     }
 
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Updated compileSdkVersion to 36 for compatibility with the latest Gradle version. This change resolves build and runtime errors encountered when targeting Android with the latest Gradle release.