### PR TITLE
fix: Add ability to build in web

### DIFF
--- a/lib/Windows/windows_platform.dart
+++ b/lib/Windows/windows_platform.dart
@@ -1,0 +1,8 @@
+// Windows-specific printer functionality
+// This file re-exports Windows printer classes and constants
+
+export 'package:ffi/ffi.dart' show using;
+export 'package:win32/win32.dart' show PRINTER_ENUM_LOCAL;
+
+export 'print_data.dart';
+export 'printers_data.dart';

--- a/lib/Windows/windows_stub.dart
+++ b/lib/Windows/windows_stub.dart
@@ -1,0 +1,28 @@
+// Stub implementation for non-Windows platforms
+// This file provides empty implementations for Windows-specific functionality
+
+// Win32 constants stub
+const int PRINTER_ENUM_LOCAL = 0x00000002;
+
+class PrinterNames {
+  PrinterNames(int flags);
+
+  Iterable<String> all() sync* {
+    // No Windows printers available on non-Windows platforms
+  }
+}
+
+class RawPrinter {
+  RawPrinter(String printerName, dynamic alloc);
+
+  void printEscPosWin32(List<int> data) {
+    throw UnsupportedError(
+      'Windows printing is not supported on this platform',
+    );
+  }
+}
+
+// Stub implementation for FFI's using function
+R using<R>(R Function(dynamic allocator) computation) {
+  throw UnsupportedError('FFI using function is not supported on web platform');
+}

--- a/lib/printer_manager.dart
+++ b/lib/printer_manager.dart
@@ -4,13 +4,11 @@ import 'dart:async';
 import 'dart:developer';
 import 'dart:io';
 
-import 'package:ffi/ffi.dart';
 import 'package:flutter/services.dart';
 import 'package:universal_ble/universal_ble.dart';
-import 'package:win32/win32.dart';
+import 'Windows/windows_platform.dart'
+    if (dart.library.html) 'Windows/windows_stub.dart';
 
-import 'Windows/print_data.dart';
-import 'Windows/printers_data.dart';
 import 'flutter_thermal_printer_platform_interface.dart';
 import 'utils/printer.dart';
 


### PR DESCRIPTION
I added the ability to build the package inside web apps. For example, our application works both on desktops and on the web. Printing is not the main component of the application to the extent that we would give up on the web.