### PR TITLE
feat(ble): add configurable connection stabilization delay;

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,30 @@ Handles long data by cropping images and printing them in chunks to ensure seaml
 ### BLE State Monitoring
 Provides real-time monitoring for Bluetooth states, ensuring proactive error handling and reconnections.
 
+### BLE Connection Configuration
+Customize BLE connection behavior to optimize for different printer models:
+
+```dart
+// Global configuration (applies to all BLE connections)
+FlutterThermalPrinter.instance.bleConfig =
+    BleConfig(connectionStabilizationDelay: Duration(seconds: 3));
+
+// Per-connection override for specific devices
+await FlutterThermalPrinter.instance.connect(
+  printer,
+  connectionStabilizationDelay: Duration(seconds: 2),
+);
+
+// Default behavior (10 seconds) - no configuration needed
+await FlutterThermalPrinter.instance.connect(printer);
+```
+
+| Configuration | Use Case |
+|---------------|----------|
+| Global config | Set once for consistent behavior across all connections |
+| Per-call override | Fine-tune for specific printer models that connect faster/slower |
+| Default (10s) | Backwards compatible, works with most printers |
+
 ---
 
 ## Notes and Recommendations

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -11,3 +11,4 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+app/.cxx

--- a/lib/flutter_thermal_printer.dart
+++ b/lib/flutter_thermal_printer.dart
@@ -8,10 +8,12 @@ import 'package:image/image.dart' as img;
 import 'package:screenshot/screenshot.dart';
 
 import 'printer_manager.dart';
+import 'utils/ble_config.dart';
 import 'utils/printer.dart';
 
 export 'package:esc_pos_utils_plus/esc_pos_utils_plus.dart';
 export 'package:flutter_thermal_printer/network/network_printer.dart';
+export 'package:flutter_thermal_printer/utils/ble_config.dart';
 export 'package:universal_ble/universal_ble.dart';
 
 /// Main class for thermal printer operations across all platforms
@@ -19,7 +21,8 @@ export 'package:universal_ble/universal_ble.dart';
 /// This class provides a unified interface for printing operations
 /// on Windows (USB/BLE) and other platforms (Android/iOS/macOS).
 class FlutterThermalPrinter {
-  FlutterThermalPrinter._();
+  FlutterThermalPrinter._({BleConfig bleConfig = const BleConfig()})
+      : _bleConfig = bleConfig;
 
   // ==========================================================================
   // STATIC VARIABLES AND INSTANCE
@@ -31,6 +34,19 @@ class FlutterThermalPrinter {
   static FlutterThermalPrinter get instance {
     _instance ??= FlutterThermalPrinter._();
     return _instance!;
+  }
+
+  // ==========================================================================
+  // BLE CONFIGURATION
+  // ==========================================================================
+
+  BleConfig _bleConfig;
+
+  BleConfig get bleConfig => _bleConfig;
+
+  set bleConfig(BleConfig config) {
+    _bleConfig = config;
+    PrinterManager.instance.bleConfig = config;
   }
 
   // ==========================================================================
@@ -50,8 +66,14 @@ class FlutterThermalPrinter {
   // ==========================================================================
 
   /// Connect to a printer device
-  Future<bool> connect(Printer device) async =>
-      PrinterManager.instance.connect(device);
+  Future<bool> connect(
+    Printer device, {
+    Duration? connectionStabilizationDelay,
+  }) async =>
+      PrinterManager.instance.connect(
+        device,
+        connectionStabilizationDelay: connectionStabilizationDelay,
+      );
 
   /// Disconnect from a printer device
   Future<void> disconnect(Printer device) async {

--- a/lib/utils/ble_config.dart
+++ b/lib/utils/ble_config.dart
@@ -1,0 +1,19 @@
+class BleConfig {
+  const BleConfig({
+    this.connectionStabilizationDelay = const Duration(seconds: 10),
+  });
+
+  final Duration connectionStabilizationDelay;
+
+  BleConfig copyWith({
+    Duration? connectionStabilizationDelay,
+  }) =>
+      BleConfig(
+        connectionStabilizationDelay:
+            connectionStabilizationDelay ?? this.connectionStabilizationDelay,
+      );
+
+  @override
+  String toString() =>
+      'BleConfig(connectionStabilizationDelay: $connectionStabilizationDelay)';
+}

--- a/test/unit/ble_config_test.dart
+++ b/test/unit/ble_config_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_thermal_printer/utils/ble_config.dart';
+
+void main() {
+  group('BleConfig', () {
+    group('constructor', () {
+      test('uses default connectionStabilizationDelay of 10 seconds', () {
+        const config = BleConfig();
+        expect(
+            config.connectionStabilizationDelay, const Duration(seconds: 10));
+      });
+
+      test('accepts custom connectionStabilizationDelay', () {
+        const config = BleConfig(
+          connectionStabilizationDelay: Duration(seconds: 5),
+        );
+        expect(config.connectionStabilizationDelay, const Duration(seconds: 5));
+      });
+
+      test('accepts zero duration', () {
+        const config = BleConfig(
+          connectionStabilizationDelay: Duration.zero,
+        );
+        expect(config.connectionStabilizationDelay, Duration.zero);
+      });
+
+      test('accepts milliseconds precision', () {
+        const config = BleConfig(
+          connectionStabilizationDelay: Duration(milliseconds: 500),
+        );
+        expect(
+          config.connectionStabilizationDelay,
+          const Duration(milliseconds: 500),
+        );
+      });
+
+      test('is const constructible', () {
+        const config1 = BleConfig();
+        const config2 = BleConfig();
+        expect(identical(config1, config2), isTrue);
+      });
+    });
+
+    group('copyWith', () {
+      test('returns new instance with updated connectionStabilizationDelay',
+          () {
+        const original = BleConfig(
+          // ignore: avoid_redundant_argument_values
+          connectionStabilizationDelay: Duration(seconds: 10),
+        );
+        final copied = original.copyWith(
+          connectionStabilizationDelay: const Duration(seconds: 3),
+        );
+
+        expect(
+          copied.connectionStabilizationDelay,
+          const Duration(seconds: 3),
+        );
+        expect(
+          original.connectionStabilizationDelay,
+          const Duration(seconds: 10),
+        );
+      });
+
+      test('preserves value when null passed', () {
+        const original = BleConfig(
+          connectionStabilizationDelay: Duration(seconds: 7),
+        );
+        final copied = original.copyWith();
+
+        expect(
+          copied.connectionStabilizationDelay,
+          const Duration(seconds: 7),
+        );
+      });
+
+      test('returns different instance', () {
+        const original = BleConfig();
+        final copied = original.copyWith();
+
+        expect(identical(original, copied), isFalse);
+      });
+    });
+
+    group('toString', () {
+      test('includes connectionStabilizationDelay', () {
+        const config = BleConfig(
+          connectionStabilizationDelay: Duration(seconds: 5),
+        );
+        final result = config.toString();
+
+        expect(result, contains('BleConfig'));
+        expect(result, contains('connectionStabilizationDelay'));
+        expect(result, contains('0:00:05'));
+      });
+
+      test('formats default duration correctly', () {
+        const config = BleConfig();
+        final result = config.toString();
+
+        expect(result, contains('0:00:10'));
+      });
+    });
+
+    group('equality', () {
+      test('const instances with same values are identical', () {
+        const config1 = BleConfig(
+          connectionStabilizationDelay: Duration(seconds: 5),
+        );
+        const config2 = BleConfig(
+          connectionStabilizationDelay: Duration(seconds: 5),
+        );
+
+        expect(identical(config1, config2), isTrue);
+      });
+
+      test('default const instances are identical', () {
+        const config1 = BleConfig();
+        const config2 = BleConfig();
+
+        expect(identical(config1, config2), isTrue);
+      });
+    });
+
+    group('edge cases', () {
+      test('handles very long duration', () {
+        const config = BleConfig(
+          connectionStabilizationDelay: Duration(hours: 1),
+        );
+        expect(config.connectionStabilizationDelay, const Duration(hours: 1));
+      });
+
+      test('handles microseconds', () {
+        const config = BleConfig(
+          connectionStabilizationDelay: Duration(microseconds: 100),
+        );
+        expect(
+          config.connectionStabilizationDelay,
+          const Duration(microseconds: 100),
+        );
+      });
+    });
+  });
+}

--- a/test/unit/flutter_thermal_printer_class_test.dart
+++ b/test/unit/flutter_thermal_printer_class_test.dart
@@ -103,6 +103,40 @@ void main() {
         );
       });
     });
+
+    group('bleConfig', () {
+      test('has default config with 10 second delay', () {
+        final config = FlutterThermalPrinter.instance.bleConfig;
+        expect(
+          config.connectionStabilizationDelay,
+          const Duration(seconds: 10),
+        );
+      });
+
+      test('bleConfig setter updates the configuration', () {
+        final originalConfig = FlutterThermalPrinter.instance.bleConfig;
+
+        FlutterThermalPrinter.instance.bleConfig =
+            const BleConfig(connectionStabilizationDelay: Duration(seconds: 5));
+
+        final newConfig = FlutterThermalPrinter.instance.bleConfig;
+        expect(
+          newConfig.connectionStabilizationDelay,
+          const Duration(seconds: 5),
+        );
+
+        FlutterThermalPrinter.instance.bleConfig = originalConfig;
+      });
+
+      test('bleConfig getter returns current config', () {
+        final config1 = FlutterThermalPrinter.instance.bleConfig;
+        final config2 = FlutterThermalPrinter.instance.bleConfig;
+        expect(
+          config1.connectionStabilizationDelay,
+          config2.connectionStabilizationDelay,
+        );
+      });
+    });
   });
 
   group('Exports verification', () {
@@ -144,6 +178,12 @@ void main() {
     test('FlutterThermalPrinterNetwork is exported', () {
       final network = FlutterThermalPrinterNetwork('127.0.0.1');
       expect(network, isNotNull);
+    });
+
+    test('BleConfig is exported', () {
+      const config = BleConfig();
+      expect(config, isNotNull);
+      expect(config.connectionStabilizationDelay, const Duration(seconds: 10));
     });
   });
 }

--- a/test/unit/printer_manager_test.dart
+++ b/test/unit/printer_manager_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_thermal_printer/flutter_thermal_printer_platform_interface.dart';
 import 'package:flutter_thermal_printer/printer_manager.dart';
+import 'package:flutter_thermal_printer/utils/ble_config.dart';
 import 'package:flutter_thermal_printer/utils/printer.dart';
 
 import '../mocks/mock_platform.dart';
@@ -169,6 +170,57 @@ void main() {
         await PrinterManager.instance.stopScan(stopBle: false);
       });
     });
+
+    group('bleConfig', () {
+      test('has default config with 10 second delay', () {
+        final config = PrinterManager.instance.bleConfig;
+        expect(
+          config.connectionStabilizationDelay,
+          const Duration(seconds: 10),
+        );
+      });
+
+      test('bleConfig setter updates the configuration', () {
+        final originalConfig = PrinterManager.instance.bleConfig;
+
+        PrinterManager.instance.bleConfig =
+            const BleConfig(connectionStabilizationDelay: Duration(seconds: 3));
+
+        final newConfig = PrinterManager.instance.bleConfig;
+        expect(
+          newConfig.connectionStabilizationDelay,
+          const Duration(seconds: 3),
+        );
+
+        PrinterManager.instance.bleConfig = originalConfig;
+      });
+
+      test('bleConfig getter returns current config', () {
+        final config1 = PrinterManager.instance.bleConfig;
+        final config2 = PrinterManager.instance.bleConfig;
+        expect(
+          config1.connectionStabilizationDelay,
+          config2.connectionStabilizationDelay,
+        );
+      });
+
+      test('config changes persist across accesses', () {
+        final originalConfig = PrinterManager.instance.bleConfig;
+
+        PrinterManager.instance.bleConfig =
+            const BleConfig(connectionStabilizationDelay: Duration(seconds: 7));
+
+        expect(
+          PrinterManager.instance.bleConfig.connectionStabilizationDelay,
+          const Duration(seconds: 7),
+        );
+        expect(
+          PrinterManager.instance.bleConfig.connectionStabilizationDelay,
+          const Duration(seconds: 7),
+        );
+
+        PrinterManager.instance.bleConfig = originalConfig;
+      });
+    });
   });
 }
-


### PR DESCRIPTION
## Summary

Adds configurable BLE connection stabilization delay to address user reports of 10+ second connection times on Android devices.

## Changes

### New Features
- **`BleConfig` class** (`lib/utils/ble_config.dart`) - Configuration object for BLE settings
- **`bleConfig` getter/setter** on `FlutterThermalPrinter` and `PrinterManager` - Global configuration
- **`connectionStabilizationDelay` parameter** on `connect()` - Per-connection override

### Usage

```

// Global configuration (applies to all BLE connections)
FlutterThermalPrinter.instance.bleConfig =
    BleConfig(connectionStabilizationDelay: Duration(seconds: 3));

// Per-connection override
await FlutterThermalPrinter.instance.connect(
  printer,
  connectionStabilizationDelay: Duration(seconds: 2),
);

// Default behavior (10 seconds) - no changes needed
await FlutterThermalPrinter.instance.connect(printer);

```

## Backwards Compatibility

✅ **No breaking changes** - Default behavior remains 10 seconds, matching previous versions.

## Tests

- Added 22 new unit tests covering `BleConfig` class and integration

## Documentation

- Updated README with new feature section