### PR TITLE
fix(ble): carry advertisement data (services, serviceData, manufacturerDataList) through to Printer

### DIFF
--- a/lib/printer_manager.dart
+++ b/lib/printer_manager.dart
@@ -475,6 +475,9 @@ class PrinterManager {
                 name: scanResult.name,
                 connectionType: ConnectionType.BLE,
                 isConnected: isConnected,
+                services: scanResult.services,
+                serviceData: scanResult.serviceData,
+                manufacturerDataList: scanResult.manufacturerDataList,
               ),
             );
           }
@@ -499,7 +502,9 @@ class PrinterManager {
     if (index == -1) {
       _devices.add(printer);
     } else {
-      _devices[index] = printer;
+      // System-device and connection-state records carry no advertisement
+      // payload, so keep the one the scan already resolved for this device.
+      _devices[index] = printer.mergeAdvertisementData(_devices[index]);
     }
     if (printer.connectionType == ConnectionType.BLE &&
         (printer.address?.isNotEmpty ?? false)) {
@@ -550,6 +555,9 @@ class PrinterManager {
             name: deviceName,
             connectionType: ConnectionType.BLE,
             isConnected: isConnected,
+            services: device.services,
+            serviceData: device.serviceData,
+            manufacturerDataList: device.manufacturerDataList,
           ),
         );
       }

--- a/lib/printer_manager.dart
+++ b/lib/printer_manager.dart
@@ -504,7 +504,10 @@ class PrinterManager {
     } else {
       // System-device and connection-state records carry no advertisement
       // payload, so keep the one the scan already resolved for this device.
-      _devices[index] = printer.mergeAdvertisementData(_devices[index]);
+      _devices[index] = Printer.mergeAdvertisementData(
+        previous: _devices[index],
+        incoming: printer,
+      );
     }
     if (printer.connectionType == ConnectionType.BLE &&
         (printer.address?.isNotEmpty ?? false)) {
@@ -555,9 +558,6 @@ class PrinterManager {
             name: deviceName,
             connectionType: ConnectionType.BLE,
             isConnected: isConnected,
-            services: device.services,
-            serviceData: device.serviceData,
-            manufacturerDataList: device.manufacturerDataList,
           ),
         );
       }

--- a/lib/utils/printer.dart
+++ b/lib/utils/printer.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: constant_identifier_names
 
+import 'dart:typed_data';
+
 import 'package:universal_ble/universal_ble.dart';
 
 /// Optimized printer model with better data validation and serialization
@@ -11,6 +13,9 @@ class Printer extends BleDevice {
     this.isConnected,
     this.vendorId,
     this.productId,
+    super.services,
+    super.serviceData,
+    super.manufacturerDataList,
   }) : super(deviceId: address ?? '', name: name ?? '');
 
   /// Create Printer from JSON with validation
@@ -68,6 +73,10 @@ class Printer extends BleDevice {
   }
 
   /// Create a copy with updated fields
+  ///
+  /// Advertisement data ([services], [serviceData], [manufacturerDataList]) is
+  /// carried over unless explicitly overridden, so connection-state updates do
+  /// not discard what the scan reported.
   Printer copyWith({
     String? address,
     String? name,
@@ -75,6 +84,9 @@ class Printer extends BleDevice {
     bool? isConnected,
     String? vendorId,
     String? productId,
+    List<String>? services,
+    Map<String, Uint8List>? serviceData,
+    List<ManufacturerData>? manufacturerDataList,
   }) =>
       Printer(
         address: address ?? this.address,
@@ -83,7 +95,35 @@ class Printer extends BleDevice {
         isConnected: isConnected ?? this.isConnected,
         vendorId: vendorId ?? this.vendorId,
         productId: productId ?? this.productId,
+        services: services ?? this.services,
+        serviceData: serviceData ?? this.serviceData,
+        manufacturerDataList: manufacturerDataList ?? this.manufacturerDataList,
       );
+
+  /// Inherit [previous]'s advertisement data when this record carries none.
+  ///
+  /// Devices reported by `getSystemDevices()` or by a connection-state change
+  /// have no advertisement payload, so replacing a scanned record with one of
+  /// them would drop the service UUIDs the scan already resolved.
+  Printer mergeAdvertisementData(Printer previous) {
+    final inheritServices = services.isEmpty && previous.services.isNotEmpty;
+    final inheritServiceData =
+        serviceData.isEmpty && previous.serviceData.isNotEmpty;
+    final inheritManufacturerData = manufacturerDataList.isEmpty &&
+        previous.manufacturerDataList.isNotEmpty;
+
+    if (!inheritServices && !inheritServiceData && !inheritManufacturerData) {
+      return this;
+    }
+
+    return copyWith(
+      services: inheritServices ? previous.services : services,
+      serviceData: inheritServiceData ? previous.serviceData : serviceData,
+      manufacturerDataList: inheritManufacturerData
+          ? previous.manufacturerDataList
+          : manufacturerDataList,
+    );
+  }
 
   /// Generate unique identifier for the printer
   String get uniqueId {

--- a/lib/utils/printer.dart
+++ b/lib/utils/printer.dart
@@ -100,28 +100,43 @@ class Printer extends BleDevice {
         manufacturerDataList: manufacturerDataList ?? this.manufacturerDataList,
       );
 
-  /// Inherit [previous]'s advertisement data when this record carries none.
+  /// Carry [previous]'s advertisement data over to [incoming] when [incoming]
+  /// has none of its own.
   ///
-  /// Devices reported by `getSystemDevices()` or by a connection-state change
-  /// have no advertisement payload, so replacing a scanned record with one of
-  /// them would drop the service UUIDs the scan already resolved.
-  Printer mergeAdvertisementData(Printer previous) {
-    final inheritServices = services.isEmpty && previous.services.isNotEmpty;
-    final inheritServiceData =
-        serviceData.isEmpty && previous.serviceData.isNotEmpty;
-    final inheritManufacturerData = manufacturerDataList.isEmpty &&
-        previous.manufacturerDataList.isNotEmpty;
-
-    if (!inheritServices && !inheritServiceData && !inheritManufacturerData) {
-      return this;
+  /// Records from `getSystemDevices()` or from a connection-state change carry
+  /// no advertisement payload, so replacing a scanned record with one of them
+  /// would drop the service UUIDs the scan already resolved.
+  ///
+  /// The decision is all-or-nothing on purpose. A record that carries any
+  /// advertisement data is treated as authoritative for all three fields, so a
+  /// scan result whose `serviceData` is legitimately empty this time does not
+  /// keep reporting bytes the peripheral has stopped advertising.
+  ///
+  /// Named parameters rather than a receiver and an argument: the two are
+  /// interchangeable at the call site and getting the order backwards would
+  /// silently discard every fresh `isConnected` or `name` update.
+  static Printer mergeAdvertisementData({
+    required Printer previous,
+    required Printer incoming,
+  }) {
+    final hasOwnData = incoming.services.isNotEmpty ||
+        incoming.serviceData.isNotEmpty ||
+        incoming.manufacturerDataList.isNotEmpty;
+    if (hasOwnData) {
+      return incoming;
     }
 
-    return copyWith(
-      services: inheritServices ? previous.services : services,
-      serviceData: inheritServiceData ? previous.serviceData : serviceData,
-      manufacturerDataList: inheritManufacturerData
-          ? previous.manufacturerDataList
-          : manufacturerDataList,
+    final hasInheritable = previous.services.isNotEmpty ||
+        previous.serviceData.isNotEmpty ||
+        previous.manufacturerDataList.isNotEmpty;
+    if (!hasInheritable) {
+      return incoming;
+    }
+
+    return incoming.copyWith(
+      services: previous.services,
+      serviceData: previous.serviceData,
+      manufacturerDataList: previous.manufacturerDataList,
     );
   }
 

--- a/test/unit/printer_test.dart
+++ b/test/unit/printer_test.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_thermal_printer/utils/printer.dart';
+import 'package:universal_ble/universal_ble.dart';
 
 void main() {
   group('Printer', () {
@@ -495,6 +498,120 @@ void main() {
     test('name override works', () {
       final printer = Printer(name: 'Custom Name', address: 'addr');
       expect(printer.name, 'Custom Name');
+    });
+  });
+
+  group('advertisement data', () {
+    final serviceData = <String, Uint8List>{
+      '000018f0-0000-1000-8000-00805f9b34fb': Uint8List.fromList([1, 2, 3]),
+    };
+    final manufacturerDataList = [
+      ManufacturerData(0x004c, Uint8List.fromList([9, 8])),
+    ];
+
+    test('constructor forwards advertisement data to BleDevice', () {
+      final printer = Printer(
+        address: 'addr',
+        name: 'name',
+        connectionType: ConnectionType.BLE,
+        services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+        serviceData: serviceData,
+        manufacturerDataList: manufacturerDataList,
+      );
+
+      expect(printer.services, ['000018f0-0000-1000-8000-00805f9b34fb']);
+      expect(printer.serviceData, serviceData);
+      expect(printer.manufacturerDataList, manufacturerDataList);
+    });
+
+    test('defaults to empty advertisement data', () {
+      final printer = Printer(address: 'addr');
+
+      expect(printer.services, isEmpty);
+      expect(printer.serviceData, isEmpty);
+      expect(printer.manufacturerDataList, isEmpty);
+    });
+
+    test('copyWith preserves advertisement data', () {
+      final original = Printer(
+        address: 'addr',
+        name: 'name',
+        connectionType: ConnectionType.BLE,
+        services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+        serviceData: serviceData,
+        manufacturerDataList: manufacturerDataList,
+      );
+
+      final copy = original.copyWith(isConnected: true);
+
+      expect(copy.isConnected, true);
+      expect(copy.services, original.services);
+      expect(copy.serviceData, original.serviceData);
+      expect(copy.manufacturerDataList, original.manufacturerDataList);
+    });
+
+    test('copyWith can override advertisement data', () {
+      final original = Printer(
+        address: 'addr',
+        services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+      );
+
+      final copy = original.copyWith(
+        services: const ['0000180d-0000-1000-8000-00805f9b34fb'],
+      );
+
+      expect(copy.services, ['0000180d-0000-1000-8000-00805f9b34fb']);
+    });
+
+    group('mergeAdvertisementData', () {
+      test('keeps previous data when this record carries none', () {
+        final scanned = Printer(
+          address: 'addr',
+          name: 'name',
+          connectionType: ConnectionType.BLE,
+          services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+          serviceData: serviceData,
+          manufacturerDataList: manufacturerDataList,
+        );
+        final systemRecord = Printer(
+          address: 'addr',
+          name: 'name',
+          connectionType: ConnectionType.BLE,
+          isConnected: true,
+        );
+
+        final merged = systemRecord.mergeAdvertisementData(scanned);
+
+        expect(merged.isConnected, true);
+        expect(merged.services, scanned.services);
+        expect(merged.serviceData, scanned.serviceData);
+        expect(merged.manufacturerDataList, scanned.manufacturerDataList);
+      });
+
+      test('keeps its own data when it carries some', () {
+        final previous = Printer(
+          address: 'addr',
+          services: const ['0000180d-0000-1000-8000-00805f9b34fb'],
+        );
+        final incoming = Printer(
+          address: 'addr',
+          services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+        );
+
+        final merged = incoming.mergeAdvertisementData(previous);
+
+        expect(merged.services, ['000018f0-0000-1000-8000-00805f9b34fb']);
+      });
+
+      test('returns identical instance when nothing to inherit', () {
+        final incoming = Printer(address: 'addr');
+        final previous = Printer(address: 'addr');
+
+        expect(
+          identical(incoming.mergeAdvertisementData(previous), incoming),
+          true,
+        );
+      });
     });
   });
 }

--- a/test/unit/printer_test.dart
+++ b/test/unit/printer_test.dart
@@ -564,7 +564,7 @@ void main() {
     });
 
     group('mergeAdvertisementData', () {
-      test('keeps previous data when this record carries none', () {
+      test('carries previous data over when incoming has none', () {
         final scanned = Printer(
           address: 'addr',
           name: 'name',
@@ -580,7 +580,10 @@ void main() {
           isConnected: true,
         );
 
-        final merged = systemRecord.mergeAdvertisementData(scanned);
+        final merged = Printer.mergeAdvertisementData(
+          previous: scanned,
+          incoming: systemRecord,
+        );
 
         expect(merged.isConnected, true);
         expect(merged.services, scanned.services);
@@ -588,7 +591,7 @@ void main() {
         expect(merged.manufacturerDataList, scanned.manufacturerDataList);
       });
 
-      test('keeps its own data when it carries some', () {
+      test('keeps incoming data when incoming carries some', () {
         final previous = Printer(
           address: 'addr',
           services: const ['0000180d-0000-1000-8000-00805f9b34fb'],
@@ -598,19 +601,72 @@ void main() {
           services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
         );
 
-        final merged = incoming.mergeAdvertisementData(previous);
+        final merged = Printer.mergeAdvertisementData(
+          previous: previous,
+          incoming: incoming,
+        );
 
         expect(merged.services, ['000018f0-0000-1000-8000-00805f9b34fb']);
       });
 
-      test('returns identical instance when nothing to inherit', () {
+      test('does not keep stale serviceData alongside fresh services', () {
+        final previous = Printer(
+          address: 'addr',
+          services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+          serviceData: serviceData,
+        );
+        final incoming = Printer(
+          address: 'addr',
+          services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+        );
+
+        final merged = Printer.mergeAdvertisementData(
+          previous: previous,
+          incoming: incoming,
+        );
+
+        expect(merged.serviceData, isEmpty);
+      });
+
+      test('returns incoming unchanged when there is nothing to inherit', () {
         final incoming = Printer(address: 'addr');
         final previous = Printer(address: 'addr');
 
         expect(
-          identical(incoming.mergeAdvertisementData(previous), incoming),
+          identical(
+            Printer.mergeAdvertisementData(
+              previous: previous,
+              incoming: incoming,
+            ),
+            incoming,
+          ),
           true,
         );
+      });
+
+      test('inheriting keeps the incoming connection state, not previous', () {
+        // With the arguments swapped, every fresh isConnected/name update
+        // would be silently discarded; this pins the direction.
+        final previous = Printer(
+          address: 'addr',
+          name: 'old name',
+          isConnected: false,
+          services: const ['000018f0-0000-1000-8000-00805f9b34fb'],
+        );
+        final incoming = Printer(
+          address: 'addr',
+          name: 'new name',
+          isConnected: true,
+        );
+
+        final merged = Printer.mergeAdvertisementData(
+          previous: previous,
+          incoming: incoming,
+        );
+
+        expect(merged.name, 'new name');
+        expect(merged.isConnected, true);
+        expect(merged.services, previous.services);
       });
     });
   });


### PR DESCRIPTION
Closes #49.

`_getBLEPrinters` copies only `deviceId` and `name` out of `UniversalBle.scanStream`, so the advertisement payload (`services`, `serviceData`, `manufacturerDataList`) is dropped and the only filter left is whether the device has a name. An app cannot tell a printer from any other BLE peripheral in range.

Narrower fix than I suggested in the issue: `Printer` already extends `BleDevice`, which declares all three fields, and has since `universal_ble` 2.0.1, so the `^2.0.1` constraint stays. Scan data goes to `super` through three super parameters, no new public fields.

Two other spots had to change or the UUIDs only survive until the first sync tick:

- `copyWith` rebuilt `Printer` from its six parameters and dropped the payload. `_syncKnownBleConnectionStates` and `_updateBleConnectionState` both call it from the `_bleStateSyncInterval` timer.
- `_updateOrAddPrinter` replaced the stored record wholesale, and `getSystemDevices()` records carry no payload, so they overwrote scan data every tick. `Printer.mergeAdvertisementData` now keeps the existing payload when the incoming record has none. It is all or nothing, so a record with any payload stays authoritative for all three fields and `serviceData` cannot go stale. Static with named parameters, since swapping receiver and argument would silently discard fresh `isConnected` and `name` updates.

`_syncSystemBleDevices` deliberately does not forward the three fields. On Linux `BlueZDevice.toBleDevice` fills `services` from BlueZ's `UUIDs`, which is every known GATT service after pairing rather than the advertised set, so forwarding it would replace scan-resolved UUIDs on every tick.

`toJson`/`fromJson` unchanged: this is scan state, not persisted identity. Say the word if you want it there. `version:` and `CHANGELOG.md` left to your release flow.

11 new cases in `test/unit/printer_test.dart`; full suite passes (198 tests) and `flutter analyze` shows the same 12 pre-existing infos as `main`.

Result: `Printer.services` carries the advertised UUIDs, so an app can match against known printer services like `000018f0-0000-1000-8000-00805f9b34fb` instead of guessing from the name.
